### PR TITLE
Fix build with glibc >= 2.27

### DIFF
--- a/src/mod_path.c
+++ b/src/mod_path.c
@@ -1,6 +1,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <sys/sysmacros.h>
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <unistd.h>


### PR DESCRIPTION
With newer versions of glibc, the build fails due to a deprecated header.

Error was:

```
src/mod_path.c:176:19: error: called object ‘major’ is not a function or function pointer
    major = (long)major(st.st_rdev);
                  ^~~~~
```

Tested on Ubuntu Disco 19.04.